### PR TITLE
Allow sequence format (file.%04d.exr / file.####.exr)

### DIFF
--- a/comfy_oiio/nodes.py
+++ b/comfy_oiio/nodes.py
@@ -133,7 +133,7 @@ def retrieve_sequence(filepath:str) -> List[str]:
         if files:
             return [files[0]]
         if sequences:
-            return sequences[0]
+            return list(sequences[0])
 
         raise ValueError(f"No readable images found in {filepath}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 openimageio>=3.0.3.1
+clique=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 openimageio>=3.0.3.1
-clique=2.0.0
+clique==2.0.0


### PR DESCRIPTION
Hello,

At first, thank you for your custom node, which is really useful, we are a company working in VFX and we encounter plenty issue related to color shift. Now we can standardize with OCIO.

I don't know If my pull request will be useful to many other people. But for us, we work with images sequence formated like this:
- my_path/my_file.%04d.exr [10-20]
Or nuke:
- my_path/my_file.####.exr

I've allowed the reading of sequence images regardless of their format:
my_path/my_file.####.exr
my_path/my_file.####.exr [100-200]
my_path/my_file.%04d.exr
my_path/my_file.%04d.exr [10-20,30]

This pull requires a new "clique" dependencies to manage the images sequence.

Thank you for reading,
I hope this will be useful.